### PR TITLE
Wrap everything in a closure

### DIFF
--- a/u2f-api.js
+++ b/u2f-api.js
@@ -10,11 +10,15 @@
 
 'use strict';
 
-if (!('u2f' in window) && 'chrome' in window && chrome.runtime) {
+(function (){
+  if ('u2f' in window || !('chrome' in window) || !chrome.runtime) {
+    return;
+  }
+
   /** Namespace for the U2F api.
    * @type {Object}
    */
-  var u2f = {};
+  var u2f = window.u2f = {};
 
   /**
    * The U2F extension id
@@ -297,4 +301,4 @@ if (!('u2f' in window) && 'chrome' in window && chrome.runtime) {
       port.postMessage(req);
     });
   };
-}
+})();


### PR DESCRIPTION
The `'u2f' in window` check was returning true because the `var u2f` was being hoisted. This PR addresses this by wrapping everything in a closure and explicitly setting `window.u2f`.

/cc @dgraham @josh
