### PR TITLE
Remove jQuery dependency

### DIFF
--- a/u2f-api-polyfill.js
+++ b/u2f-api-polyfill.js
@@ -234,7 +234,7 @@
    * @private
    */
   u2f.isIosChrome_ = function() {
-    return $.inArray(navigator.platform, ["iPhone", "iPad", "iPod"]) > -1;
+    return ["iPhone", "iPad", "iPod"].indexOf(navigator.platform) > -1;
   };
 
   /**


### PR DESCRIPTION
This jQuery dependency seemed to go unnoticed. It's the only reference to `$` in the whole file. `Array.indexOf` is fine in IE9+.

This fixes the code path in Microsoft Edge when jQuery isn't exported to `$` on the page.
