### PR TITLE
Fix UA detection

### DIFF
--- a/u2f-api-polyfill.js
+++ b/u2f-api-polyfill.js
@@ -11,7 +11,8 @@
 'use strict';
 
 (function (){
-  if ('u2f' in window || !('chrome' in window)) {
+  var isChrome = 'chrome' in window && !window.navigator.userAgent.includes('Edge');
+  if ('u2f' in window || !isChrome) {
     return;
   }
 


### PR DESCRIPTION
This package had been looking for `window.chrome` as a way to detect if the UA was Google Chrome. Apparently Microsoft Edge defines this API as well though, so it's not an effective test. This PR adds a check of `window.navigator.userAgent` in addition to the `window.chrome` check.

/cc @mislav — Any advice on a better way to check for Chrome would be appreciated.
